### PR TITLE
Fix broken link

### DIFF
--- a/book_src/architecture.md
+++ b/book_src/architecture.md
@@ -9,7 +9,7 @@ and [`Resolve`](https://docs.rs/rkyv/latest/rkyv/trait.Resolve.html).
 
 Writers are types that accept bytes and write them in order to some output. The most basic example
 of a writer might be a simple file. Writers can additionally provide the position of the next byte,
-which is important for [relative pointers](/relative-pointers.html).
+which is important for [relative pointers](relative-pointers.html).
 
 ## Archive
 


### PR DESCRIPTION
```
warning: Absolute link should be made relative
   ┌─ architecture.md:12:24
   │
12 │ which is important for [relative pointers](/relative-pointers.html).
   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Absolute link should be made relative
   │
   = When viewing a document directly from the file system and click on an
     absolute link (e.g. `/index.md`), the browser will try to navigate to
     `/index.md` on the current file system (i.e. the `index.md` file inside
     `/` or `C:\`) instead of the `index.md` file at book's base directory as
     intended.
     
     This warning helps avoid the situation where everything will seem to work
     fine when viewed using a web server (e.g. GitHub Pages or `mdbook serve`),
     but users viewing the book from the file system may encounter broken links.
     
     To ignore this warning, you can edit `book.toml` and set the warning policy to
     "ignore".
     
         [output.linkcheck]
         warning-policy = "ignore"
     
     For more details, see https://github.com/Michael-F-Bryan/mdbook-linkcheck/issues/33
   = Suggestion: change the link to "relative-pointers.html"

```

`mdbook-linkcheck` shows that, I clicked on that link and it was broken while I was reading the book.