### PR TITLE
Run tests in WebAssembly in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions-rs/install@v0.1
+      with:
+        crate: wasm-pack
+        version: latest
+        use-tool-cache: true
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run wasm tests
+      run: cd rkyv_test && wasm-pack test --node

--- a/rkyv/build.rs
+++ b/rkyv/build.rs
@@ -3,7 +3,7 @@ use std::env;
 fn main() {
     let target = env::var("TARGET").unwrap();
 
-    let emscripten = target == "asmjs-unknown-emscripten"
+    let is_wasm = target == "asmjs-unknown-emscripten"
         || target == "wasm32-unknown-emscripten"
         || target == "wasm32-unknown-unknown";
 
@@ -13,7 +13,7 @@ fn main() {
         || target.starts_with("powerpc64")
         || target.starts_with("sparc64")
         || target.starts_with("mips64el");
-    let has_atomic32 = has_atomic64 || emscripten;
+    let has_atomic32 = has_atomic64 || is_wasm;
 
     if has_atomic64 {
         println!("cargo:rustc-cfg=rkyv_atomic_64");

--- a/rkyv_test/Cargo.toml
+++ b/rkyv_test/Cargo.toml
@@ -18,10 +18,16 @@ rkyv_typename = { path = "../rkyv_typename", default-features = false, optional 
 
 [features]
 default = ["std", "const_generics", "validation"]
+default_not_wasm = ["std_not_wasm", "validation_not_wasm"] # https://github.com/rustwasm/wasm-pack/issues/698
 const_generics = ["rkyv/const_generics", "rkyv_typename/const_generics"]
 size_64 = ["rkyv/size_64"]
 nightly = ["rkyv_dyn/nightly"]
-std = ["rkyv/std", "rkyv_dyn", "rkyv_typename/std"]
+std = ["rkyv/std", "rkyv_typename/std"]
+std_not_wasm = ["rkyv/std", "rkyv_dyn", "rkyv_typename/std"]
 strict = ["rkyv/strict"]
-validation = ["bytecheck", "std", "rkyv/validation", "rkyv_dyn/validation"]
+validation = ["bytecheck", "std", "rkyv/validation"]
+validation_not_wasm = ["bytecheck", "std", "rkyv/validation", "rkyv_dyn/validation"]
 vtable_cache = ["rkyv_dyn/vtable_cache"]
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/rkyv_test/Cargo.toml
+++ b/rkyv_test/Cargo.toml
@@ -18,16 +18,15 @@ rkyv_typename = { path = "../rkyv_typename", default-features = false, optional 
 
 [features]
 default = ["std", "const_generics", "validation"]
-default_not_wasm = ["std_not_wasm", "validation_not_wasm"] # https://github.com/rustwasm/wasm-pack/issues/698
 const_generics = ["rkyv/const_generics", "rkyv_typename/const_generics"]
 size_64 = ["rkyv/size_64"]
 nightly = ["rkyv_dyn/nightly"]
-std = ["rkyv/std", "rkyv_typename/std"]
-std_not_wasm = ["rkyv/std", "rkyv_dyn", "rkyv_typename/std"]
+std = ["rkyv/std", "rkyv_dyn", "rkyv_typename/std"]
 strict = ["rkyv/strict"]
-validation = ["bytecheck", "std", "rkyv/validation"]
-validation_not_wasm = ["bytecheck", "std", "rkyv/validation", "rkyv_dyn/validation"]
+validation = ["bytecheck", "std", "rkyv/validation", "rkyv_dyn/validation"]
 vtable_cache = ["rkyv_dyn/vtable_cache"]
 
-[dev-dependencies]
+not_wasm = []
+
+[target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/rkyv_test/Cargo.toml
+++ b/rkyv_test/Cargo.toml
@@ -15,6 +15,7 @@ ptr_meta = { version = "0.1" }
 rkyv = { path = "../rkyv", default-features = false }
 rkyv_dyn = { path = "../rkyv_dyn", default-features = false, optional = true }
 rkyv_typename = { path = "../rkyv_typename", default-features = false, optional = true }
+wasm-bindgen-test = { version = "0.3", optional = true }
 
 [features]
 default = ["std", "const_generics", "validation"]
@@ -25,8 +26,12 @@ std = ["rkyv/std", "rkyv_dyn", "rkyv_typename/std"]
 strict = ["rkyv/strict"]
 validation = ["bytecheck", "std", "rkyv/validation", "rkyv_dyn/validation"]
 vtable_cache = ["rkyv_dyn/vtable_cache"]
+wasm = ["wasm-bindgen-test"]
 
-not_wasm = []
-
+# HACK: Tests should be run with `wasm-pack test --node -- --features "wasm"` but wasm-pack runs
+# `cargo build` before `cargo test` and doesn't pass the additional arguments to the build step. To
+# work around this, we just manually add the dependencies for the `wasm` feature when the target is
+# set to `wasm32-unknown-unknown`.
+# Blocking bug: https://github.com/rustwasm/wasm-pack/issues/698
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/rkyv_test/build.rs
+++ b/rkyv_test/build.rs
@@ -1,35 +1,19 @@
 use std::env;
 
+// HACK: Tests should be run with `wasm-pack test --node -- --features "wasm"` but wasm-pack runs
+// `cargo build` before `cargo test` and doesn't pass the additional arguments to the build step. To
+// work around this, we just manually turn on the `wasm` feature from the build script.
+// Blocking bug: https://github.com/rustwasm/wasm-pack/issues/698
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let target = env::var("TARGET").unwrap();
 
-    let emscripten = target == "asmjs-unknown-emscripten"
+    let is_wasm = target == "asmjs-unknown-emscripten"
         || target == "wasm32-unknown-emscripten"
         || target == "wasm32-unknown-unknown";
 
-    if !emscripten {
-        println!("cargo:rustc-cfg=feature=\"not_wasm\"");
-    }
-
-    if target == "wasm32-unknown-unknown" {
-        println!("cargo:rustc-cfg=wasm_bindgen");
-    }
-
-    let has_atomic64 = target.starts_with("x86_64")
-        || target.starts_with("i686")
-        || target.starts_with("aarch64")
-        || target.starts_with("powerpc64")
-        || target.starts_with("sparc64")
-        || target.starts_with("mips64el");
-    let has_atomic32 = has_atomic64 || emscripten;
-
-    if has_atomic64 {
-        println!("cargo:rustc-cfg=rkyv_atomic_64");
-    }
-
-    if has_atomic32 {
-        println!("cargo:rustc-cfg=rkyv_atomic");
+    if is_wasm {
+        println!("cargo:rustc-cfg=feature=\"wasm\"");
     }
 }

--- a/rkyv_test/build.rs
+++ b/rkyv_test/build.rs
@@ -11,7 +11,9 @@ fn main() {
 
     if !emscripten {
         println!("cargo:rustc-cfg=feature=\"not_wasm\"");
-    } else {
+    }
+
+    if target == "wasm32-unknown-unknown" {
         println!("cargo:rustc-cfg=wasm_bindgen");
     }
 

--- a/rkyv_test/build.rs
+++ b/rkyv_test/build.rs
@@ -4,14 +4,15 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let target = env::var("TARGET").unwrap();
-    let using_default = env::var("CARGO_FEATURE_DEFAULT").is_ok();
 
     let emscripten = target == "asmjs-unknown-emscripten"
         || target == "wasm32-unknown-emscripten"
         || target == "wasm32-unknown-unknown";
 
-    if !emscripten && using_default {
-        println!("cargo:rustc-cfg=feature=\"default_not_wasm\"");
+    if !emscripten {
+        println!("cargo:rustc-cfg=feature=\"not_wasm\"");
+    } else {
+        println!("cargo:rustc-cfg=wasm_bindgen");
     }
 
     let has_atomic64 = target.starts_with("x86_64")

--- a/rkyv_test/build.rs
+++ b/rkyv_test/build.rs
@@ -1,11 +1,18 @@
 use std::env;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
     let target = env::var("TARGET").unwrap();
+    let using_default = env::var("CARGO_FEATURE_DEFAULT").is_ok();
 
     let emscripten = target == "asmjs-unknown-emscripten"
         || target == "wasm32-unknown-emscripten"
         || target == "wasm32-unknown-unknown";
+
+    if !emscripten && using_default {
+        println!("cargo:rustc-cfg=feature=\"default_not_wasm\"");
+    }
 
     let has_atomic64 = target.starts_with("x86_64")
         || target.starts_with("i686")

--- a/rkyv_test/src/lib.rs
+++ b/rkyv_test/src/lib.rs
@@ -5,6 +5,8 @@ mod validation;
 
 #[cfg(test)]
 mod util {
+    wasm_bindgen_test::wasm_bindgen_test_configure!();
+
     use rkyv::{
         archived_root, archived_unsized_root,
         ser::{serializers::BufferSerializer, Serializer},
@@ -123,8 +125,10 @@ mod util {
 #[cfg(test)]
 mod no_std_tests {
     use crate::util::*;
+    use wasm_bindgen_test::*;
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_primitives() {
         test_archive(&());
         test_archive(&true);
@@ -146,6 +150,7 @@ mod no_std_tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_refs() {
         #[cfg(not(feature = "strict"))]
         test_archive_ref::<[i32; 4]>(&[1, 2, 3, 4]);
@@ -154,12 +159,14 @@ mod no_std_tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_slices() {
         test_archive_ref::<str>("hello world");
         test_archive_ref::<[i32]>([1, 2, 3, 4].as_ref());
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_empty_slice() {
         test_archive_ref::<[i32; 0]>(&[]);
         test_archive_ref::<[i32]>([].as_ref());
@@ -184,7 +191,10 @@ mod tests {
         SerializeUnsized,
     };
 
+    use wasm_bindgen_test::*;
+
     #[test]
+    #[wasm_bindgen_test]
     fn archive_containers() {
         test_archive_container(&Box::new(42));
         test_archive_container(&"".to_string().into_boxed_str());
@@ -198,6 +208,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_composition() {
         test_archive(&Some(Box::new(42)));
         test_archive(&Some("hello world".to_string().into_boxed_str()));
@@ -208,7 +219,10 @@ mod tests {
     }
 
     mod example {
+        use wasm_bindgen_test::*;
+
         #[test]
+        #[wasm_bindgen_test]
         fn archive_example() {
             use rkyv::{
                 archived_root,
@@ -250,6 +264,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_hash_map() {
         use std::collections::HashMap;
 
@@ -289,6 +304,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_unit_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -299,6 +315,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_tuple_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -308,6 +325,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_simple_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -341,6 +359,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_generic_struct() {
         pub trait TestTrait {
             type Associated: PartialEq;
@@ -382,6 +401,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_enum() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -408,6 +428,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_generic_enum() {
         pub trait TestTrait {
             type Associated: PartialEq;
@@ -445,6 +466,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_copy() {
         #[derive(Archive, Serialize, Deserialize, Clone, Copy, PartialEq)]
         #[archive(copy)]
@@ -493,6 +515,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_derives() {
         #[derive(Archive, Serialize, Clone)]
         #[archive(derive(Clone, Debug, PartialEq))]
@@ -511,6 +534,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rkyv_dyn")]
     fn manual_archive_dyn() {
         use rkyv::{ArchivePointee, ArchivedMetadata};
         use rkyv_dyn::{
@@ -664,6 +688,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rkyv_dyn")]
     fn archive_dyn() {
         use rkyv::AlignedVec;
         use rkyv_dyn::archive_dyn;
@@ -715,6 +740,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rkyv_dyn")]
     fn archive_dyn_generic() {
         use rkyv::archived_value;
         use rkyv_dyn::archive_dyn;
@@ -844,6 +870,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn derive_visibility() {
         mod inner {
             #[derive(super::Archive, super::Serialize)]
@@ -877,6 +904,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn basic_mutable_refs() {
         let mut serializer = AlignedSerializer::new(AlignedVec::new());
         serializer.serialize_value(&42i32).unwrap();
@@ -888,6 +916,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn struct_mutable_refs() {
         use std::collections::HashMap;
 
@@ -963,6 +992,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn enum_mutable_ref() {
         #[allow(dead_code)]
         #[derive(Archive, Serialize)]
@@ -995,6 +1025,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rkyv_dyn")]
     fn mutable_dyn_ref() {
         use rkyv_dyn::archive_dyn;
         use rkyv_typename::TypeName;
@@ -1048,6 +1079,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn recursive_structures() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -1063,6 +1095,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_root() {
         use rkyv::{archived_value, Aligned};
 
@@ -1097,6 +1130,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_more_std() {
         use core::{
             num::NonZeroU8,
@@ -1138,6 +1172,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_shared_ptr() {
         use std::rc::Rc;
 
@@ -1164,7 +1199,8 @@ mod tests {
             b: shared.clone(),
         };
 
-        let mut serializer = SharedSerializerAdapter::new(AlignedSerializer::new(AlignedVec::new()));
+        let mut serializer =
+            SharedSerializerAdapter::new(AlignedSerializer::new(AlignedVec::new()));
         serializer
             .serialize_value(&value)
             .expect("failed to archive value");
@@ -1222,6 +1258,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_unsized_shared_ptr() {
         use std::rc::Rc;
 
@@ -1243,6 +1280,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn archive_weak_ptr() {
         use std::rc::{Rc, Weak};
 
@@ -1268,7 +1306,8 @@ mod tests {
             b: Rc::downgrade(&shared),
         };
 
-        let mut serializer = SharedSerializerAdapter::new(AlignedSerializer::new(AlignedVec::new()));
+        let mut serializer =
+            SharedSerializerAdapter::new(AlignedSerializer::new(AlignedVec::new()));
         serializer
             .serialize_value(&value)
             .expect("failed to archive value");
@@ -1337,6 +1376,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn derive_attributes() {
         use rkyv::Fallible;
 
@@ -1394,6 +1434,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn compare() {
         #[derive(Archive, Serialize, Deserialize)]
         #[archive(compare(PartialEq, PartialOrd))]
@@ -1418,6 +1459,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn default_type_parameters() {
         #[derive(Archive, Serialize, Deserialize)]
         pub struct TupleFoo<T = i32>(T);
@@ -1435,8 +1477,12 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn check_util_bounds() {
-        use rkyv::{Aligned, ser::{Serializer, serializers::AlignedSerializer}};
+        use rkyv::{
+            ser::{serializers::AlignedSerializer, Serializer},
+            Aligned,
+        };
         fn check<T: Serializer>() {}
 
         check::<BufferSerializer<[u8; 256]>>();

--- a/rkyv_test/src/lib.rs
+++ b/rkyv_test/src/lib.rs
@@ -5,6 +5,7 @@ mod validation;
 
 #[cfg(test)]
 mod util {
+    #[cfg(wasm_bindgen)]
     wasm_bindgen_test::wasm_bindgen_test_configure!();
 
     use rkyv::{
@@ -125,10 +126,12 @@ mod util {
 #[cfg(test)]
 mod no_std_tests {
     use crate::util::*;
+
+    #[cfg(wasm_bindgen)]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_primitives() {
         test_archive(&());
         test_archive(&true);
@@ -150,7 +153,7 @@ mod no_std_tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_refs() {
         #[cfg(not(feature = "strict"))]
         test_archive_ref::<[i32; 4]>(&[1, 2, 3, 4]);
@@ -159,14 +162,14 @@ mod no_std_tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_slices() {
         test_archive_ref::<str>("hello world");
         test_archive_ref::<[i32]>([1, 2, 3, 4].as_ref());
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_empty_slice() {
         test_archive_ref::<[i32; 0]>(&[]);
         test_archive_ref::<[i32]>([].as_ref());
@@ -191,10 +194,11 @@ mod tests {
         SerializeUnsized,
     };
 
+    #[cfg(wasm_bindgen)]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_containers() {
         test_archive_container(&Box::new(42));
         test_archive_container(&"".to_string().into_boxed_str());
@@ -208,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_composition() {
         test_archive(&Some(Box::new(42)));
         test_archive(&Some("hello world".to_string().into_boxed_str()));
@@ -219,10 +223,11 @@ mod tests {
     }
 
     mod example {
+        #[cfg(wasm_bindgen)]
         use wasm_bindgen_test::*;
 
         #[test]
-        #[wasm_bindgen_test]
+        #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
         fn archive_example() {
             use rkyv::{
                 archived_root,
@@ -264,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_hash_map() {
         use std::collections::HashMap;
 
@@ -304,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_unit_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -315,7 +320,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_tuple_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -325,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_simple_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -359,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_generic_struct() {
         pub trait TestTrait {
             type Associated: PartialEq;
@@ -401,7 +406,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_enum() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -428,7 +433,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_generic_enum() {
         pub trait TestTrait {
             type Associated: PartialEq;
@@ -466,7 +471,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_copy() {
         #[derive(Archive, Serialize, Deserialize, Clone, Copy, PartialEq)]
         #[archive(copy)]
@@ -515,7 +520,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_derives() {
         #[derive(Archive, Serialize, Clone)]
         #[archive(derive(Clone, Debug, PartialEq))]
@@ -534,7 +539,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rkyv_dyn")]
+    #[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
     fn manual_archive_dyn() {
         use rkyv::{ArchivePointee, ArchivedMetadata};
         use rkyv_dyn::{
@@ -688,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rkyv_dyn")]
+    #[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
     fn archive_dyn() {
         use rkyv::AlignedVec;
         use rkyv_dyn::archive_dyn;
@@ -740,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rkyv_dyn")]
+    #[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
     fn archive_dyn_generic() {
         use rkyv::archived_value;
         use rkyv_dyn::archive_dyn;
@@ -870,7 +875,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn derive_visibility() {
         mod inner {
             #[derive(super::Archive, super::Serialize)]
@@ -904,7 +909,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn basic_mutable_refs() {
         let mut serializer = AlignedSerializer::new(AlignedVec::new());
         serializer.serialize_value(&42i32).unwrap();
@@ -916,7 +921,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn struct_mutable_refs() {
         use std::collections::HashMap;
 
@@ -992,7 +997,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn enum_mutable_ref() {
         #[allow(dead_code)]
         #[derive(Archive, Serialize)]
@@ -1025,7 +1030,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rkyv_dyn")]
+    #[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
     fn mutable_dyn_ref() {
         use rkyv_dyn::archive_dyn;
         use rkyv_typename::TypeName;
@@ -1079,7 +1084,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn recursive_structures() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -1095,7 +1100,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_root() {
         use rkyv::{archived_value, Aligned};
 
@@ -1130,7 +1135,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_more_std() {
         use core::{
             num::NonZeroU8,
@@ -1172,7 +1177,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_shared_ptr() {
         use std::rc::Rc;
 
@@ -1258,7 +1263,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_unsized_shared_ptr() {
         use std::rc::Rc;
 
@@ -1280,7 +1285,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn archive_weak_ptr() {
         use std::rc::{Rc, Weak};
 
@@ -1376,7 +1381,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn derive_attributes() {
         use rkyv::Fallible;
 
@@ -1434,7 +1439,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn compare() {
         #[derive(Archive, Serialize, Deserialize)]
         #[archive(compare(PartialEq, PartialOrd))]
@@ -1459,7 +1464,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn default_type_parameters() {
         #[derive(Archive, Serialize, Deserialize)]
         pub struct TupleFoo<T = i32>(T);
@@ -1477,7 +1482,7 @@ mod tests {
     }
 
     #[test]
-    #[wasm_bindgen_test]
+    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
     fn check_util_bounds() {
         use rkyv::{
             ser::{serializers::AlignedSerializer, Serializer},

--- a/rkyv_test/src/lib.rs
+++ b/rkyv_test/src/lib.rs
@@ -5,7 +5,7 @@ mod validation;
 
 #[cfg(test)]
 mod util {
-    #[cfg(wasm_bindgen)]
+    #[cfg(feature = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!();
 
     use rkyv::{
@@ -127,11 +127,11 @@ mod util {
 mod no_std_tests {
     use crate::util::*;
 
-    #[cfg(wasm_bindgen)]
+    #[cfg(feature = "wasm")]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_primitives() {
         test_archive(&());
         test_archive(&true);
@@ -153,7 +153,7 @@ mod no_std_tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_refs() {
         #[cfg(not(feature = "strict"))]
         test_archive_ref::<[i32; 4]>(&[1, 2, 3, 4]);
@@ -162,14 +162,14 @@ mod no_std_tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_slices() {
         test_archive_ref::<str>("hello world");
         test_archive_ref::<[i32]>([1, 2, 3, 4].as_ref());
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_empty_slice() {
         test_archive_ref::<[i32; 0]>(&[]);
         test_archive_ref::<[i32]>([].as_ref());
@@ -190,15 +190,14 @@ mod tests {
             serializers::{AlignedSerializer, BufferSerializer},
             SeekSerializer, Serializer,
         },
-        AlignedVec, Archive, ArchiveUnsized, Archived, Deserialize, DeserializeUnsized, Serialize,
-        SerializeUnsized,
+        AlignedVec, Archive, Archived, Deserialize, Serialize,
     };
 
-    #[cfg(wasm_bindgen)]
+    #[cfg(feature = "wasm")]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_containers() {
         test_archive_container(&Box::new(42));
         test_archive_container(&"".to_string().into_boxed_str());
@@ -212,7 +211,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_composition() {
         test_archive(&Some(Box::new(42)));
         test_archive(&Some("hello world".to_string().into_boxed_str()));
@@ -223,11 +222,11 @@ mod tests {
     }
 
     mod example {
-        #[cfg(wasm_bindgen)]
+        #[cfg(feature = "wasm")]
         use wasm_bindgen_test::*;
 
         #[test]
-        #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+        #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
         fn archive_example() {
             use rkyv::{
                 archived_root,
@@ -269,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_hash_map() {
         use std::collections::HashMap;
 
@@ -309,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_unit_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -320,7 +319,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_tuple_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -330,7 +329,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_simple_struct() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -364,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_generic_struct() {
         pub trait TestTrait {
             type Associated: PartialEq;
@@ -406,7 +405,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_enum() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -433,7 +432,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_generic_enum() {
         pub trait TestTrait {
             type Associated: PartialEq;
@@ -471,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_copy() {
         #[derive(Archive, Serialize, Deserialize, Clone, Copy, PartialEq)]
         #[archive(copy)]
@@ -520,7 +519,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_derives() {
         #[derive(Archive, Serialize, Clone)]
         #[archive(derive(Clone, Debug, PartialEq))]
@@ -539,9 +538,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
+    #[cfg(not(feature = "wasm"))]
     fn manual_archive_dyn() {
-        use rkyv::{ArchivePointee, ArchivedMetadata};
+        use rkyv::{ArchivePointee, ArchiveUnsized, ArchivedMetadata, DeserializeUnsized, SerializeUnsized};
         use rkyv_dyn::{
             register_impl, ArchivedDynMetadata, DeserializeDyn, DynDeserializer, DynError,
             RegisteredImpl, SerializeDyn,
@@ -693,7 +692,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
+    #[cfg(not(feature = "wasm"))]
     fn archive_dyn() {
         use rkyv::AlignedVec;
         use rkyv_dyn::archive_dyn;
@@ -745,7 +744,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
+    #[cfg(not(feature = "wasm"))]
     fn archive_dyn_generic() {
         use rkyv::archived_value;
         use rkyv_dyn::archive_dyn;
@@ -875,7 +874,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn derive_visibility() {
         mod inner {
             #[derive(super::Archive, super::Serialize)]
@@ -909,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn basic_mutable_refs() {
         let mut serializer = AlignedSerializer::new(AlignedVec::new());
         serializer.serialize_value(&42i32).unwrap();
@@ -921,7 +920,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn struct_mutable_refs() {
         use std::collections::HashMap;
 
@@ -997,7 +996,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn enum_mutable_ref() {
         #[allow(dead_code)]
         #[derive(Archive, Serialize)]
@@ -1030,7 +1029,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
+    #[cfg(not(feature = "wasm"))]
     fn mutable_dyn_ref() {
         use rkyv_dyn::archive_dyn;
         use rkyv_typename::TypeName;
@@ -1084,7 +1083,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn recursive_structures() {
         #[derive(Archive, Serialize, Deserialize, PartialEq)]
         #[archive(compare(PartialEq))]
@@ -1100,7 +1099,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_root() {
         use rkyv::{archived_value, Aligned};
 
@@ -1135,7 +1134,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_more_std() {
         use core::{
             num::NonZeroU8,
@@ -1177,7 +1176,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_shared_ptr() {
         use std::rc::Rc;
 
@@ -1263,7 +1262,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_unsized_shared_ptr() {
         use std::rc::Rc;
 
@@ -1285,7 +1284,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn archive_weak_ptr() {
         use std::rc::{Rc, Weak};
 
@@ -1381,7 +1380,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn derive_attributes() {
         use rkyv::Fallible;
 
@@ -1439,7 +1438,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn compare() {
         #[derive(Archive, Serialize, Deserialize)]
         #[archive(compare(PartialEq, PartialOrd))]
@@ -1464,7 +1463,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn default_type_parameters() {
         #[derive(Archive, Serialize, Deserialize)]
         pub struct TupleFoo<T = i32>(T);
@@ -1482,7 +1481,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     fn check_util_bounds() {
         use rkyv::{
             ser::{serializers::AlignedSerializer, Serializer},

--- a/rkyv_test/src/validation.rs
+++ b/rkyv_test/src/validation.rs
@@ -15,6 +15,7 @@ use std::{
     error::Error,
 };
 
+#[cfg(wasm_bindgen)]
 use wasm_bindgen_test::*;
 
 const BUFFER_SIZE: usize = 512;
@@ -32,7 +33,7 @@ where
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn basic_functionality() {
     // Regular archiving
     let value = Some("Hello world".to_string());
@@ -105,7 +106,7 @@ fn basic_functionality() {
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn invalid_tags() {
     // Invalid archive (invalid tag)
     let synthetic_buf = Aligned([
@@ -121,7 +122,7 @@ fn invalid_tags() {
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn overlapping_claims() {
     // Invalid archive (overlapping claims)
     let synthetic_buf = Aligned([
@@ -139,7 +140,7 @@ fn overlapping_claims() {
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn cycle_detection() {
     use rkyv::{
         validation::{ArchiveBoundsContext, ArchiveMemoryContext},
@@ -223,7 +224,7 @@ fn cycle_detection() {
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn derive_unit_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -233,7 +234,7 @@ fn derive_unit_struct() {
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn derive_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -251,7 +252,7 @@ fn derive_struct() {
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn derive_tuple_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -265,7 +266,7 @@ fn derive_tuple_struct() {
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn derive_enum() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -284,7 +285,7 @@ fn derive_enum() {
 }
 
 #[test]
-#[wasm_bindgen_test]
+#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
 fn hashmap() {
     let mut map = HashMap::new();
     map.insert("Hello".to_string(), 12);
@@ -304,7 +305,7 @@ fn hashmap() {
 }
 
 #[test]
-#[cfg(feature = "rkyv_dyn")]
+#[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
 fn check_dyn() {
     use rkyv::Archived;
     use rkyv_dyn::archive_dyn;

--- a/rkyv_test/src/validation.rs
+++ b/rkyv_test/src/validation.rs
@@ -15,7 +15,7 @@ use std::{
     error::Error,
 };
 
-#[cfg(wasm_bindgen)]
+#[cfg(feature = "wasm")]
 use wasm_bindgen_test::*;
 
 const BUFFER_SIZE: usize = 512;
@@ -33,7 +33,7 @@ where
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn basic_functionality() {
     // Regular archiving
     let value = Some("Hello world".to_string());
@@ -106,7 +106,7 @@ fn basic_functionality() {
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn invalid_tags() {
     // Invalid archive (invalid tag)
     let synthetic_buf = Aligned([
@@ -122,7 +122,7 @@ fn invalid_tags() {
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn overlapping_claims() {
     // Invalid archive (overlapping claims)
     let synthetic_buf = Aligned([
@@ -140,7 +140,7 @@ fn overlapping_claims() {
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn cycle_detection() {
     use rkyv::{
         validation::{ArchiveBoundsContext, ArchiveMemoryContext},
@@ -224,7 +224,7 @@ fn cycle_detection() {
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn derive_unit_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -234,7 +234,7 @@ fn derive_unit_struct() {
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn derive_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -252,7 +252,7 @@ fn derive_struct() {
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn derive_tuple_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -266,7 +266,7 @@ fn derive_tuple_struct() {
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn derive_enum() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -285,7 +285,7 @@ fn derive_enum() {
 }
 
 #[test]
-#[cfg_attr(wasm_bindgen, wasm_bindgen_test)]
+#[cfg_attr(feature = "wasm", wasm_bindgen_test)]
 fn hashmap() {
     let mut map = HashMap::new();
     map.insert("Hello".to_string(), 12);
@@ -305,7 +305,7 @@ fn hashmap() {
 }
 
 #[test]
-#[cfg(all(feature = "rkyv_dyn", feature = "not_wasm"))]
+#[cfg(not(feature = "wasm"))]
 fn check_dyn() {
     use rkyv::Archived;
     use rkyv_dyn::archive_dyn;

--- a/rkyv_test/src/validation.rs
+++ b/rkyv_test/src/validation.rs
@@ -15,6 +15,8 @@ use std::{
     error::Error,
 };
 
+use wasm_bindgen_test::*;
+
 const BUFFER_SIZE: usize = 512;
 
 fn serialize_and_check<T: Serialize<AlignedSerializer<AlignedVec>>>(value: &T)
@@ -30,6 +32,7 @@ where
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn basic_functionality() {
     // Regular archiving
     let value = Some("Hello world".to_string());
@@ -102,6 +105,7 @@ fn basic_functionality() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn invalid_tags() {
     // Invalid archive (invalid tag)
     let synthetic_buf = Aligned([
@@ -117,6 +121,7 @@ fn invalid_tags() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn overlapping_claims() {
     // Invalid archive (overlapping claims)
     let synthetic_buf = Aligned([
@@ -134,6 +139,7 @@ fn overlapping_claims() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn cycle_detection() {
     use rkyv::{
         validation::{ArchiveBoundsContext, ArchiveMemoryContext},
@@ -217,6 +223,7 @@ fn cycle_detection() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn derive_unit_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -226,6 +233,7 @@ fn derive_unit_struct() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn derive_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -243,6 +251,7 @@ fn derive_struct() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn derive_tuple_struct() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -256,6 +265,7 @@ fn derive_tuple_struct() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn derive_enum() {
     #[derive(Archive, Serialize)]
     #[archive(derive(CheckBytes))]
@@ -274,6 +284,7 @@ fn derive_enum() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn hashmap() {
     let mut map = HashMap::new();
     map.insert("Hello".to_string(), 12);
@@ -293,6 +304,7 @@ fn hashmap() {
 }
 
 #[test]
+#[cfg(feature = "rkyv_dyn")]
 fn check_dyn() {
     use rkyv::Archived;
     use rkyv_dyn::archive_dyn;


### PR DESCRIPTION
I want to use rkyv in WebAssembly, so this PR makes the necessary changes to rkyv_test to make it compile and run on WASM targets. It also adds a step to CI to run these tests in a Node.js environment. 

Note that this does not (yet) ensure that serialized data are portable between x86 and WASM. I also had to disable rkyv_dyn in WASM tests due to its reliance on the inventory crate, [which does not support WASM targets](https://github.com/dtolnay/inventory/issues/13). 