### PR TITLE
Update bytecheck version

### DIFF
--- a/rkyv/Cargo.toml
+++ b/rkyv/Cargo.toml
@@ -14,7 +14,7 @@ readme = "crates-io.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { version = "0.4", optional = true }
+bytecheck = { version = "0.5", optional = true }
 memoffset = "0.6"
 ptr_meta = { version = "0.1" }
 rkyv_derive = { version = "=0.6.3", path = "../rkyv_derive" }

--- a/rkyv/src/std_impl/chd/validation.rs
+++ b/rkyv/src/std_impl/chd/validation.rs
@@ -12,7 +12,7 @@ use core::{
     fmt,
     hash::{Hash, Hasher},
 };
-use std::{alloc::LayoutErr, error::Error};
+use std::{alloc::LayoutError, error::Error};
 
 /// Errors that can occur while checking an archived hash map entry.
 #[derive(Debug)]
@@ -59,7 +59,7 @@ impl<K: CheckBytes<C>, V: CheckBytes<C>, C: ArchiveMemoryContext + ?Sized> Check
 #[derive(Debug)]
 pub enum HashMapError<K, V, C> {
     /// An error occured while checking the layouts of displacements or entries
-    LayoutError(LayoutErr),
+    LayoutError(LayoutError),
     /// An error occured while checking the displacements
     CheckDisplaceError(SliceCheckError<Unreachable>),
     /// An error occured while checking the entries
@@ -113,9 +113,9 @@ impl<K, V, C> From<Unreachable> for HashMapError<K, V, C> {
     }
 }
 
-impl<K, V, C> From<LayoutErr> for HashMapError<K, V, C> {
+impl<K, V, C> From<LayoutError> for HashMapError<K, V, C> {
     #[inline]
-    fn from(e: LayoutErr) -> Self {
+    fn from(e: LayoutError) -> Self {
         Self::LayoutError(e)
     }
 }

--- a/rkyv_bench/Cargo.toml
+++ b/rkyv_bench/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.3"
-bytecheck = { version = "0.4" }
+bytecheck = { version = "0.5" }
 criterion = "0.3"
 rand = "0.8"
 rand_pcg = "0.3"

--- a/rkyv_dyn/Cargo.toml
+++ b/rkyv_dyn/Cargo.toml
@@ -14,7 +14,7 @@ readme = "crates-io.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { version = "0.4", optional = true }
+bytecheck = { version = "0.5", optional = true }
 inventory = "0.1"
 lazy_static = "1.4"
 ptr_meta = { version = "0.1" }

--- a/rkyv_test/Cargo.toml
+++ b/rkyv_test/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/djkoloski/rkyv"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { version = "0.4", optional = true }
+bytecheck = { version = "0.5", optional = true }
 ptr_meta = { version = "0.1" }
 rkyv = { path = "../rkyv", default-features = false }
 rkyv_dyn = { path = "../rkyv_dyn", default-features = false, optional = true }


### PR DESCRIPTION
Update `bytecheck` version from `0.4` to `0.5`, and changed `LayoutErr` import name to avoid deprecated warning.