### PR TITLE
AsHashMap wrapper

### DIFF
--- a/rkyv/src/std_impl/chd/mod.rs
+++ b/rkyv/src/std_impl/chd/mod.rs
@@ -577,7 +577,7 @@ pub struct ArchivedHashMapResolver {
 
 impl ArchivedHashMapResolver {
     #[inline]
-    fn resolve_from_len<K, V>(
+    pub(crate) fn resolve_from_len<K, V>(
         self,
         pos: usize,
         len: usize,

--- a/rkyv/src/std_impl/chd/mod.rs
+++ b/rkyv/src/std_impl/chd/mod.rs
@@ -243,7 +243,7 @@ impl<K, V> ArchivedHashMap<K, V> {
         }
     }
 
-    pub fn serialize_from_iter<
+    pub(crate) fn serialize_from_iter<
         'a,
         KU: 'a + Serialize<S, Archived = K> + Hash + Eq,
         VU: 'a + Serialize<S, Archived = V>,


### PR DESCRIPTION
Created the `AsHashMap` "with" wrapper, as described in previous PR. I also make `serialize_from_iter` private again since `AsHashMap` wrapper can do the job and it might create confusions [(this comment)](https://github.com/djkoloski/rkyv/commit/e0b7d61d22c26a1bede8a32ea8435d663bc6660f#commitcomment-51156795)