### PR TITLE
Make `resolve_from_len public` for `rkyv_contrib` wrapper

### DIFF
--- a/rkyv/src/std_impl/chd/mod.rs
+++ b/rkyv/src/std_impl/chd/mod.rs
@@ -580,7 +580,7 @@ pub struct ArchivedHashMapResolver {
 
 impl ArchivedHashMapResolver {
     #[inline]
-    fn resolve_from_len<K, V>(
+    pub fn resolve_from_len<K, V>(
         self,
         pos: usize,
         len: usize,


### PR DESCRIPTION
As shown in [this snippet](https://github.com/djkoloski/rkyv/pull/140/files#diff-5450db3481466737220fbe031fb597a501c9b3573c4ba0057d2d4367ccc1e55cR580), `AsHashMap` wrapper needs to access `resolve_from_len` function to work. Thanks!