### PR TITLE
Do not capture Result<> type within #[derive(Serialize/Deserialize)]

### DIFF
--- a/rkyv_derive/src/deserialize.rs
+++ b/rkyv_derive/src/deserialize.rs
@@ -72,7 +72,7 @@ fn derive_deserialize_impl(
                 quote! {
                     impl #impl_generics Deserialize<#name #ty_generics, __D> for Archived<#name #ty_generics> #deserialize_where {
                         #[inline]
-                        fn deserialize(&self, deserializer: &mut __D) -> Result<#name #ty_generics, __D::Error> {
+                        fn deserialize(&self, deserializer: &mut __D) -> core::result::Result<#name #ty_generics, __D::Error> {
                             Ok(#name {
                                 #(#deserialize_fields,)*
                             })
@@ -104,7 +104,7 @@ fn derive_deserialize_impl(
                 quote! {
                     impl #impl_generics Deserialize<#name #ty_generics, __D> for Archived<#name #ty_generics> #deserialize_where {
                         #[inline]
-                        fn deserialize(&self, deserializer: &mut __D) -> Result<#name #ty_generics, __D::Error> {
+                        fn deserialize(&self, deserializer: &mut __D) -> core::result::Result<#name #ty_generics, __D::Error> {
                             Ok(#name(
                                 #(#deserialize_fields,)*
                             ))
@@ -115,7 +115,7 @@ fn derive_deserialize_impl(
             Fields::Unit => quote! {
                 impl #impl_generics Deserialize<#name #ty_generics, __D> for Archived<#name #ty_generics> #where_clause {
                     #[inline]
-                    fn deserialize(&self, _: &mut __D) -> Result<#name #ty_generics, __D::Error> {
+                    fn deserialize(&self, _: &mut __D) -> core::result::Result<#name #ty_generics, __D::Error> {
                         Ok(#name)
                     }
                 }
@@ -201,7 +201,7 @@ fn derive_deserialize_impl(
             quote! {
                 impl #impl_generics Deserialize<#name #ty_generics, __D> for Archived<#name #ty_generics> #deserialize_where {
                     #[inline]
-                    fn deserialize(&self, deserializer: &mut __D) -> Result<#name #ty_generics, __D::Error> {
+                    fn deserialize(&self, deserializer: &mut __D) -> core::result::Result<#name #ty_generics, __D::Error> {
                         Ok(match self {
                             #(#deserialize_variants,)*
                         })
@@ -294,7 +294,7 @@ fn derive_deserialize_copy_impl(
             quote! {
                 impl #impl_generics Deserialize<#name #ty_generics, __D> for Archived<#name #ty_generics> #deserialize_where {
                     #[inline]
-                    fn deserialize(&self, _: &mut __D) -> Result<Self, __D::Error> {
+                    fn deserialize(&self, _: &mut __D) -> core::result::Result<Self, __D::Error> {
                         Ok(*self)
                     }
                 }
@@ -335,7 +335,7 @@ fn derive_deserialize_copy_impl(
             quote! {
                 impl #impl_generics Deserialize<#name #ty_generics, __D> for Archived<#name #ty_generics> #deserialize_where {
                     #[inline]
-                    fn deserialize(&self, _: &mut __D) -> Result<Self, __D::Error> {
+                    fn deserialize(&self, _: &mut __D) -> core::result::Result<Self, __D::Error> {
                         Ok(*self)
                     }
                 }

--- a/rkyv_derive/src/serialize.rs
+++ b/rkyv_derive/src/serialize.rs
@@ -74,7 +74,7 @@ fn derive_serialize_impl(
                 quote! {
                     impl #impl_generics Serialize<__S> for #name #ty_generics #serialize_where {
                         #[inline]
-                        fn serialize(&self, serializer: &mut __S) -> Result<Self::Resolver, __S::Error> {
+                        fn serialize(&self, serializer: &mut __S) -> core::result::Result<Self::Resolver, __S::Error> {
                             Ok(#resolver {
                                 #(#resolver_values,)*
                             })
@@ -103,7 +103,7 @@ fn derive_serialize_impl(
                 quote! {
                     impl #impl_generics Serialize<__S> for #name #ty_generics #serialize_where {
                         #[inline]
-                        fn serialize(&self, serializer: &mut __S) -> Result<Self::Resolver, __S::Error> {
+                        fn serialize(&self, serializer: &mut __S) -> core::result::Result<Self::Resolver, __S::Error> {
                             Ok(#resolver(
                                 #(#resolver_values,)*
                             ))
@@ -115,7 +115,7 @@ fn derive_serialize_impl(
                 quote! {
                     impl #impl_generics Serialize<__S> for #name #ty_generics #where_clause {
                         #[inline]
-                        fn serialize(&self, serializer: &mut __S) -> Result<Self::Resolver, __S::Error> {
+                        fn serialize(&self, serializer: &mut __S) -> core::result::Result<Self::Resolver, __S::Error> {
                             Ok(#resolver)
                         }
                     }
@@ -198,7 +198,7 @@ fn derive_serialize_impl(
             quote! {
                 impl #impl_generics Serialize<__S> for #name #ty_generics #serialize_where {
                     #[inline]
-                    fn serialize(&self, serializer: &mut __S) -> Result<Self::Resolver, __S::Error> {
+                    fn serialize(&self, serializer: &mut __S) -> core::result::Result<Self::Resolver, __S::Error> {
                         Ok(match self {
                             #(#serialize_arms,)*
                         })
@@ -283,7 +283,7 @@ fn derive_serialize_copy_impl(
             quote! {
                 impl #impl_generics Serialize<__S> for #name #ty_generics #copy_where {
                     #[inline]
-                    fn serialize(&self, serializer: &mut __S) -> Result<Self::Resolver, __S::Error> {
+                    fn serialize(&self, serializer: &mut __S) -> core::result::Result<Self::Resolver, __S::Error> {
                         Ok(())
                     }
                 }
@@ -336,7 +336,7 @@ fn derive_serialize_copy_impl(
             quote! {
                 impl #impl_generics Serialize<__S> for #name #ty_generics #copy_where {
                     #[inline]
-                    fn serialize(&self, serializer: &mut __S) -> Result<Self::Resolver, __S::Error> {
+                    fn serialize(&self, serializer: &mut __S) -> core::result::Result<Self::Resolver, __S::Error> {
                         Ok(())
                     }
                 }


### PR DESCRIPTION
Hi!

If I have defined a type alias like `pub type Result<T> = result::Result<T, Error>` in the module where I use `#[derive(Serialize)]`, it causes compilation errors because a bare return type like `Result<..>` captures the `Result` I have in scope in *my* module and not the one used in `rkyv_derive/src/{de,}serialize.rs`.  IOW, the compiler complains that the `Result` takes one type argument, not two.