### PR TITLE
Fix build for `specialization` without `std`

### DIFF
--- a/rkyv/src/core_impl/mod.rs
+++ b/rkyv/src/core_impl/mod.rs
@@ -5,6 +5,10 @@ use crate::{
     ArchivePointee, ArchiveUnsized, Archived, ArchivedIsize, ArchivedMetadata, ArchivedUsize,
     Deserialize, DeserializeUnsized, Fallible, Serialize, SerializeUnsized,
 };
+
+#[cfg(all(not(feature = "std"), feature = "specialization"))]
+use ::alloc::vec::Vec;
+
 #[cfg(rkyv_atomic)]
 use core::sync::atomic::{
     self, AtomicBool, AtomicI16, AtomicI32, AtomicI8, AtomicU16, AtomicU32, AtomicU8,

--- a/rkyv/src/lib.rs
+++ b/rkyv/src/lib.rs
@@ -66,6 +66,9 @@
 #![cfg_attr(feature = "specialization", feature(min_specialization))]
 #![cfg_attr(feature = "specialization", feature(rustc_attrs))]
 
+#[cfg(all(not(feature = "std"), feature = "specialization"))]
+extern crate alloc;
+
 #[doc(hidden)]
 #[macro_use]
 pub mod macros;

--- a/rkyv/src/macros.rs
+++ b/rkyv/src/macros.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "std", feature = "specialization"))]
+#[cfg(feature = "specialization")]
 macro_rules! default {
     ($($fn:tt)*) => { default $($fn)* };
 }


### PR DESCRIPTION
This makes `cargo build -p rkyv --no-default-features --features specialization` work.