### PR TITLE
Fix crash with jemalloc: don't attempt to allocate zero bytes

### DIFF
--- a/rkyv/src/core_impl/mod.rs
+++ b/rkyv/src/core_impl/mod.rs
@@ -643,9 +643,13 @@ impl<S: Serializer + ?Sized> SerializeUnsized<S> for str {
 impl<D: Deserializer + ?Sized> DeserializeUnsized<str, D> for <str as ArchiveUnsized>::Archived {
     #[inline]
     unsafe fn deserialize_unsized(&self, deserializer: &mut D) -> Result<*mut (), D::Error> {
-        let bytes = deserializer.alloc(alloc::Layout::array::<u8>(self.len()).unwrap())?;
-        ptr::copy_nonoverlapping(self.as_ptr(), bytes, self.len());
-        Ok(bytes.cast())
+        if self.len() == 0 {
+            Ok(ptr::null_mut())
+        } else {
+            let bytes = deserializer.alloc(alloc::Layout::array::<u8>(self.len()).unwrap())?;
+            ptr::copy_nonoverlapping(self.as_ptr(), bytes, self.len());
+            Ok(bytes.cast())
+        }
     }
 
     #[inline]


### PR DESCRIPTION
When using jemalloc as an allocator, I was seeing crashes similar to the ones reported in #89 when deserializing empty buffers/strings. Looks like another place where this occurs was missed. I based the fix on c803c1b288472284f09611b72914ba5c794206e9 and verified locally that it works.